### PR TITLE
Define null values as valid.

### DIFF
--- a/src/Validator/Constraints/IsDecimalValidator.php
+++ b/src/Validator/Constraints/IsDecimalValidator.php
@@ -26,6 +26,10 @@ class IsDecimalValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
+        if ($value === null) {
+            return;
+        }
+
         $regexp = '/^([-]{0,1})(\d{1,}\.\d{1,})$/';
 
         if (is_float($value)) {

--- a/src/Validator/Constraints/IsEmailValidator.php
+++ b/src/Validator/Constraints/IsEmailValidator.php
@@ -26,6 +26,10 @@ class IsEmailValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
+        if ($value === null) {
+            return;
+        }
+
         $mandatory = true;
 
         if ($mandatory) {

--- a/src/Validator/Constraints/IsFalseValidator.php
+++ b/src/Validator/Constraints/IsFalseValidator.php
@@ -26,6 +26,10 @@ class IsFalseValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
+        if ($value === null) {
+            return;
+        }
+
         if (is_bool($value) && $value === false) {
             return;
         }

--- a/src/Validator/Constraints/IsIbanValidator.php
+++ b/src/Validator/Constraints/IsIbanValidator.php
@@ -30,6 +30,10 @@ class IsIbanValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
+        if ($value === null) {
+            return;
+        }
+
         if (!$constraint instanceof IsIban) {
             throw new UnexpectedTypeException($constraint, __NAMESPACE__ . '\IsIban');
         }
@@ -55,10 +59,10 @@ class IsIbanValidator extends ConstraintValidator
         if ($type->isValid()) {
             if (!is_null($countryCodes)) {
                 if (in_array($type->getCountryCode(), $countryCodes)) {
-                    return true;
+                    return;
                 }
             } else {
-                return true;
+                return;
             }
         }
 

--- a/src/Validator/Constraints/IsIntegerValidator.php
+++ b/src/Validator/Constraints/IsIntegerValidator.php
@@ -26,6 +26,10 @@ class IsIntegerValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
+        if ($value === null) {
+            return;
+        }
+
         $regexp = '/^([-]{0,1})(\d{1,})$/';
 
         if (is_int($value)) {

--- a/src/Validator/Constraints/IsIpValidator.php
+++ b/src/Validator/Constraints/IsIpValidator.php
@@ -26,6 +26,10 @@ class IsIpValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
+        if ($value === null) {
+            return;
+        }
+
         $mandatory = true;
 
         if ($mandatory) {

--- a/src/Validator/Constraints/IsNumericValidator.php
+++ b/src/Validator/Constraints/IsNumericValidator.php
@@ -26,6 +26,10 @@ class IsNumericValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
+        if ($value === null) {
+            return;
+        }
+
         if (is_numeric($value)) {
             return;
         }

--- a/src/Validator/Constraints/IsRegexpValidator.php
+++ b/src/Validator/Constraints/IsRegexpValidator.php
@@ -36,6 +36,10 @@ class IsRegexpValidator extends ConstraintValidator
             throw new ConstraintDefinitionException('Given Regexp on regexp contrain is empty');
         }
 
+        if ($value === null) {
+            return;
+        }
+
         if (preg_match($constraint->regexp, (string)$value)) {
             return;
         }

--- a/src/Validator/Constraints/IsStringValidator.php
+++ b/src/Validator/Constraints/IsStringValidator.php
@@ -26,7 +26,7 @@ class IsStringValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
-        if (is_string($value)) {
+        if (is_string($value) || $value === null) {
             return;
         }
 

--- a/src/Validator/Constraints/IsTrueValidator.php
+++ b/src/Validator/Constraints/IsTrueValidator.php
@@ -26,6 +26,10 @@ class IsTrueValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
+        if ($value === null) {
+            return;
+        }
+
         if (is_bool($value) && $value === true) {
             return;
         }

--- a/src/Validator/Constraints/IsUrlValidator.php
+++ b/src/Validator/Constraints/IsUrlValidator.php
@@ -26,6 +26,10 @@ class IsUrlValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
+        if ($value === null) {
+            return;
+        }
+
         $mandatory = true;
 
         if ($mandatory) {

--- a/tests/Entities/Product.php
+++ b/tests/Entities/Product.php
@@ -59,6 +59,7 @@ class Product
     {
         $metadata->addPropertyConstraint('productNumber', new Assert\NotBlank());
         $metadata->addPropertyConstraint('productDesc', new Assert\NotBlank());
+        $metadata->addPropertyConstraint('price', new Assert\NotBlank());
         $metadata->addPropertyConstraint('price', new NauconAsserts\IsDecimal());
     }
 }

--- a/tests/Validator/Constraints/IsDecimalValidatorTest.php
+++ b/tests/Validator/Constraints/IsDecimalValidatorTest.php
@@ -33,7 +33,7 @@ class IsDecimalValidatorTest extends AbstractConstraintValidatorTest
             array('-2.95', true),
             array('abc', false),
             array('', false),
-            array(null, false),
+            array(null, true),
         );
     }
 

--- a/tests/Validator/Constraints/IsEmailValidatorTest.php
+++ b/tests/Validator/Constraints/IsEmailValidatorTest.php
@@ -44,7 +44,7 @@ class IsEmailValidatorTest extends AbstractConstraintValidatorTest
             array('-2.95', false),
             array('abc', false),
             array('', false),
-            array(null, false),
+            array(null, true),
         );
     }
 

--- a/tests/Validator/Constraints/IsFalseValidatorTest.php
+++ b/tests/Validator/Constraints/IsFalseValidatorTest.php
@@ -36,7 +36,7 @@ class IsFalseValidatorTest extends AbstractConstraintValidatorTest
             array('-2.95', false),
             array('abc', false),
             array('', false),
-            array(null, false),
+            array(null, true),
         );
     }
 

--- a/tests/Validator/Constraints/IsIntegerValidatorTest.php
+++ b/tests/Validator/Constraints/IsIntegerValidatorTest.php
@@ -39,7 +39,7 @@ class IsIntegerValidatorTest extends AbstractConstraintValidatorTest
             array('-2.95', false),
             array('abc', false),
             array('', false),
-            array(null, false),
+            array(null, true),
         );
     }
 

--- a/tests/Validator/Constraints/IsIpValidatorTest.php
+++ b/tests/Validator/Constraints/IsIpValidatorTest.php
@@ -40,7 +40,7 @@ class IsIpValidatorTest extends AbstractConstraintValidatorTest
             array('-2.95', false),
             array('abc', false),
             array('', false),
-            array(null, false),
+            array(null, true),
         );
     }
 

--- a/tests/Validator/Constraints/IsNumericValidatorTest.php
+++ b/tests/Validator/Constraints/IsNumericValidatorTest.php
@@ -33,7 +33,7 @@ class IsNumericValidatorTest extends AbstractConstraintValidatorTest
             array('-2.95', true),
             array('abc', false),
             array('', false),
-            array(null, false),
+            array(null, true),
         );
     }
 

--- a/tests/Validator/Constraints/IsRegexpValidatorTest.php
+++ b/tests/Validator/Constraints/IsRegexpValidatorTest.php
@@ -35,7 +35,7 @@ class IsRegexpValidatorTest extends AbstractConstraintValidatorTest
             array('-2.95', '/(ipsum){1}/', false),
             array('abc', '/(ipsum){1}/', false),
             array('', '/(ipsum){1}/', false),
-            array(null, '/(ipsum){1}/', false),
+            array(null, '/(ipsum){1}/', true),
         );
     }
 

--- a/tests/Validator/Constraints/IsStringValidatorTest.php
+++ b/tests/Validator/Constraints/IsStringValidatorTest.php
@@ -34,7 +34,7 @@ class IsStringValidatorTest extends AbstractConstraintValidatorTest
             array('-2.95', true),
             array('abc', true),
             array('', true),
-            array(null, false),
+            array(null, true),
         );
     }
 

--- a/tests/Validator/Constraints/IsTrueValidatorTest.php
+++ b/tests/Validator/Constraints/IsTrueValidatorTest.php
@@ -36,7 +36,7 @@ class IsTrueValidatorTest extends AbstractConstraintValidatorTest
             array('-2.95', false),
             array('abc', false),
             array('', false),
-            array(null, false),
+            array(null, true),
         );
     }
 

--- a/tests/Validator/Constraints/IsUrlValidatorTest.php
+++ b/tests/Validator/Constraints/IsUrlValidatorTest.php
@@ -44,7 +44,7 @@ class IsUrlValidatorTest extends AbstractConstraintValidatorTest
             array('-2.95', false),
             //array('abc', false), // TODO regexp should not match
             //array('', false), // TODO regexp should not match
-            array(null, false),
+            array(null, true),
         );
     }
 


### PR DESCRIPTION
I'd like to mention a near symfony behavior.

In symfony is `null` and empty string always valid.

I will do it a piece of more strict and say: That `null` is valid, but empty string not.

### Why allow null values?

It exists cases in that I'd like to check, if a value contains a integer, but will also allow, that the value isn't filled.
`null` is the type less representation of a "not existing value". That's also why I think, that an empty string should be invalid.
When I like to force, that a value is set, then should it be via a explicit `NotBlank` validation definition.

### Summary

`null` is a "not value". A value validation like `IsInteger` should not block, because `null` does not exclude to be an integer.
Its open opportunities to have a more clear view in validation configuration.
Its allow do define a value as ie. integer and optional.

You can see the wanted effect in the test entities very clearly: [Product Validation Definition in the tests](https://github.com/naucon/Form/pull/2/files#diff-e68673a70007fb32865c9e48ee7bc731R62)