### PR TITLE
add missing doctrine dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,8 @@
     "require": {
         "php": "^5.5.9|>=7.0.8",
         "psr/log": "~1.0",
+        "doctrine/annotations": "^1.0",
+        "doctrine/cache": "^1.0",
         "naucon/utility": "~1.0",
         "naucon/htmlbuilder": "~1.0",
         "symfony/validator": "^3.0",
@@ -25,15 +27,11 @@
     "require-dev": {
         "symfony/intl": "^3.0",
         "symfony/config": "^3.0",
-        "doctrine/annotations": "~1.0",
-        "doctrine/cache": "~1.0",
         "naucon/iban": "~1.0",
         "phpunit/phpunit": "^5.6"
     },
     "suggest": {
         "symfony/config": "Is required to use xml mapping.",
-        "doctrine/annotations": "Is required to use annotation mapping.",
-        "doctrine/cache": "Is required to use annotation mapping.",
         "naucon/iban": "Is required to validate iban."
     },
     "autoload": {


### PR DESCRIPTION
The validator class unconditionally enables annotation mapping of the used Symfony Validator. See https://github.com/naucon/Form/blob/master/src/Validator/Validator.php#L46 for reference. This throws a runtime exception if the doctrine/annotations and doctrine/cache bundles are not installed.

Therefore the doctrine/annotations and doctrine/cache bundles are required dependencies of this bundle, not only dev-dependencies or suggested extra bundles.