### PR TITLE
add compatibility to Symfony 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build-test-71:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: php-actions/composer@v6
+        with:
+          version: 2
+          php_version: "7.1"
+
+      - name: PHPUnit Tests
+        uses: php-actions/phpunit@v3
+        with:
+          version: 7
+          php_version: "7.1"
+          configuration: phpunit.xml.dist
+          bootstrap: vendor/autoload.php
+  build-test-74:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: php-actions/composer@v6
+        with:
+          version: 2
+          php_version: "7.4"
+
+      - name: PHPUnit Tests
+        uses: php-actions/phpunit@v3
+        with:
+          version: 7
+          php_version: "7.4"
+          configuration: phpunit.xml.dist
+          bootstrap: vendor/autoload.php

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The package can be integrated into any php web application (min. php5.5+).
 
 ### Compatibility
 
-* PHP 5.5.9+
+* PHP 7.1 - 7.4
 
 
 Installation

--- a/composer.json
+++ b/composer.json
@@ -11,24 +11,26 @@
         }
     ],
     "require": {
-        "php": "^5.5.9|>=7.0.8",
+        "php": "^7.1",
         "psr/log": "~1.0",
         "doctrine/annotations": "^1.0",
         "doctrine/cache": "^1.0",
         "naucon/utility": "~1.0",
         "naucon/htmlbuilder": "~1.0",
-        "symfony/validator": "^3.0",
-        "symfony/property-access": "^3.0",
-        "symfony/security-csrf": "^3.0",
-        "symfony/event-dispatcher": "^3.0",
-        "symfony/finder": "^3.0",
-        "symfony/options-resolver": "^3.0"
+        "symfony/validator": "^3.2 || ^4.0",
+        "symfony/property-access": "^3.2 || ^4.0",
+        "symfony/security-csrf": "^3.2 || ^4.0",
+        "symfony/event-dispatcher": "^3.2 || ^4.0",
+        "symfony/finder": "^3.2 || ^4.0",
+        "symfony/options-resolver": "^3.2 || ^4.0",
+        "symfony/translation": "^3.2 || ^4.0",
+        "symfony/yaml": "^3.2 || ^4.0"
     },
     "require-dev": {
-        "symfony/intl": "^3.0",
-        "symfony/config": "^3.0",
+        "symfony/intl": "^3.2 || ^4.0",
+        "symfony/config": "^3.2 || ^4.0",
         "naucon/iban": "~1.0",
-        "phpunit/phpunit": "^5.6"
+        "phpunit/phpunit": "^7.0"
     },
     "suggest": {
         "symfony/config": "Is required to use xml mapping.",

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -11,8 +11,9 @@ namespace Naucon\Form\Tests;
 
 use Naucon\Form\FormCollectionInterface;
 use Naucon\Form\Configuration;
+use PHPUnit\Framework\TestCase;
 
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
     public function configProvider()
     {

--- a/tests/Entities/User.php
+++ b/tests/Entities/User.php
@@ -104,10 +104,10 @@ class User
 
     public static function loadValidatorMetadata(ClassMetadata $metadata)
     {
-        $metadata->addPropertyConstraint('username', new Assert\NotBlank());
         $metadata->addPropertyConstraint('username', new Assert\Length(
             array('min' => 5, 'max' => 50)
         ));
+        $metadata->addPropertyConstraint('username', new Assert\NotBlank());
         $metadata->addPropertyConstraint('email', new Assert\Email());
         $metadata->addPropertyConstraint('age', new Assert\Type('numeric'));
     }

--- a/tests/FormCollectionHelperTest.php
+++ b/tests/FormCollectionHelperTest.php
@@ -15,11 +15,12 @@ use Naucon\Form\FormHelper;
 use Naucon\Form\Tests\Entities\CreditCard;
 use Naucon\Form\Tests\Entities\DirectDebit;
 use Naucon\Form\Security\SynchronizerTokenBridge;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Csrf\CsrfTokenManager;
 use Symfony\Component\Security\Csrf\TokenGenerator\TokenGeneratorInterface;
 use Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface;
 
-class FormCollectionHelperTest extends \PHPUnit_Framework_TestCase
+class FormCollectionHelperTest extends TestCase
 {
     /**
      * @var TokenGeneratorInterface|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/FormCollectionTest.php
+++ b/tests/FormCollectionTest.php
@@ -16,8 +16,9 @@ use Naucon\Form\Validator\Validator;
 use Naucon\Form\Tests\Entities\Product;
 use Naucon\Form\Tests\Entities\CreditCard;
 use Naucon\Form\Tests\Entities\DirectDebit;
+use PHPUnit\Framework\TestCase;
 
-class FormCollectionTest extends \PHPUnit_Framework_TestCase
+class FormCollectionTest extends TestCase
 {
     public function entitiesProvider()
     {

--- a/tests/FormHelperTest.php
+++ b/tests/FormHelperTest.php
@@ -20,8 +20,9 @@ use Naucon\Form\Mapper\EntityContainerInterface;
 use Naucon\Form\Tests\Entities\Product;
 use Naucon\Form\Tests\Entities\User;
 use Naucon\Form\Validator\Validator;
+use PHPUnit\Framework\TestCase;
 
-class FormHelperTest extends \PHPUnit_Framework_TestCase
+class FormHelperTest extends TestCase
 {
     public function formWithConfigProvider()
     {
@@ -955,6 +956,8 @@ class FormHelperTest extends \PHPUnit_Framework_TestCase
         $configuration = new Configuration();
         $form = new Form($userEntity, 'testform', $configuration);
         $entityContainer = $form->getFirstEntityContainer();
+
+        $this->assertNotNull($entityContainer);
 
         return $entityContainer;
     }

--- a/tests/FormHelperTranslationTest.php
+++ b/tests/FormHelperTranslationTest.php
@@ -18,8 +18,9 @@ use Naucon\Form\Tests\Entities\User;
 use Naucon\Form\Tests\Entities\Product;
 use Naucon\Form\Translator\Translator;
 use Naucon\Form\Validator\Validator;
+use PHPUnit\Framework\TestCase;
 
-class FormHelperTranslationTest extends \PHPUnit_Framework_TestCase
+class FormHelperTranslationTest extends TestCase
 {
     public function formWithConfigProvider()
     {

--- a/tests/FormManagerTest.php
+++ b/tests/FormManagerTest.php
@@ -21,8 +21,9 @@ use Naucon\Form\Tests\Entities\Product;
 use Naucon\Form\Tests\Entities\Address;
 use Naucon\Form\Tests\Entities\CreditCard;
 use Naucon\Form\Tests\Entities\DirectDebit;
+use PHPUnit\Framework\TestCase;
 
-class FormManagerTest extends \PHPUnit_Framework_TestCase
+class FormManagerTest extends TestCase
 {
     /**
      * @var SynchronizerTokenInterface

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -15,8 +15,9 @@ use Naucon\Form\Validator\Validator;
 use Naucon\Form\Tests\Entities\User;
 use Naucon\Form\Tests\Entities\Product;
 use Naucon\Form\Tests\Entities\Address;
+use PHPUnit\Framework\TestCase;
 
-class FormTest extends \PHPUnit_Framework_TestCase
+class FormTest extends TestCase
 {
     public function entityProvider()
     {

--- a/tests/FormWithSynchronizerTokenBridgeTest.php
+++ b/tests/FormWithSynchronizerTokenBridgeTest.php
@@ -16,11 +16,12 @@ use Naucon\Form\Security\SynchronizerTokenBridge;
 use Naucon\Form\Tests\Entities\User;
 use Naucon\Form\Tests\Entities\Product;
 use Naucon\Form\Tests\Entities\Address;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Csrf\CsrfTokenManager;
 use Symfony\Component\Security\Csrf\TokenGenerator\TokenGeneratorInterface;
 use Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface;
 
-class FormWithSynchronizerTokenBridgeTest extends \PHPUnit_Framework_TestCase
+class FormWithSynchronizerTokenBridgeTest extends TestCase
 {
     /**
      * @var TokenGeneratorInterface|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/FormWithTranslatorBridgeTest.php
+++ b/tests/FormWithTranslatorBridgeTest.php
@@ -9,6 +9,7 @@
  */
 namespace Naucon\Form\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Translation\Formatter\MessageFormatter;
 use Symfony\Component\Translation\Translator as BaseTranslator;
@@ -20,7 +21,7 @@ use Naucon\Form\Validator\Validator;
 use Naucon\Form\Translator\TranslatorBridge;
 use Naucon\Form\Tests\Entities\User;
 
-class FormWithTranslatorBridgeTest extends \PHPUnit_Framework_TestCase
+class FormWithTranslatorBridgeTest extends TestCase
 {
     public function entityProvider()
     {
@@ -124,10 +125,6 @@ class FormWithTranslatorBridgeTest extends \PHPUnit_Framework_TestCase
         foreach ($methods as $method) {
             $this->assertEquals('', $entity->$method());
         }
-
-		$configPaths = [];
-		$configPaths['en_EN'] = __DIR__ . '/Resources/translations/validators.en.yml';
-		$configPaths['de_DE'] = __DIR__ . '/Resources/translations/validators.de.yml';
 
 		$translator = new BaseTranslator('de_DE', new MessageFormatter());
 		$translator->addLoader('xlf', new XliffFileLoader());

--- a/tests/FormWithTranslatorTest.php
+++ b/tests/FormWithTranslatorTest.php
@@ -14,8 +14,9 @@ use Naucon\Form\Configuration;
 use Naucon\Form\Tests\Entities\User;
 use Naucon\Form\Translator\Translator;
 use Naucon\Form\Validator\Validator;
+use PHPUnit\Framework\TestCase;
 
-class FormWithTranslatorTest extends \PHPUnit_Framework_TestCase
+class FormWithTranslatorTest extends TestCase
 {
     public function entityProvider()
     {

--- a/tests/FormWithValidatorBridgeTest.php
+++ b/tests/FormWithValidatorBridgeTest.php
@@ -14,9 +14,10 @@ use Naucon\Form\Configuration;
 use Naucon\Form\Validator\ValidatorBridge;
 use Naucon\Form\Tests\Entities\UserWithConfig;
 use Naucon\Form\Tests\Entities\UserWithAnnotation;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Validation;
 
-class FormWithValidatorBridgeTest extends \PHPUnit_Framework_TestCase
+class FormWithValidatorBridgeTest extends TestCase
 {
     public function entityProvider()
     {

--- a/tests/FormWithValidatorTest.php
+++ b/tests/FormWithValidatorTest.php
@@ -14,8 +14,9 @@ use Naucon\Form\Configuration;
 use Naucon\Form\Validator\Validator;
 use Naucon\Form\Tests\Entities\UserWithConfig;
 use Naucon\Form\Tests\Entities\UserWithAnnotation;
+use PHPUnit\Framework\TestCase;
 
-class FormWithValidatorTest extends \PHPUnit_Framework_TestCase
+class FormWithValidatorTest extends TestCase
 {
     public function entityProvider()
     {

--- a/tests/Helper/FormHelperChoiceCheckboxTest.php
+++ b/tests/Helper/FormHelperChoiceCheckboxTest.php
@@ -16,8 +16,9 @@ use Naucon\Utility\Map;
 use Naucon\Form\FormInterface;
 use Naucon\Form\Mapper\EntityContainerInterface;
 use Naucon\Form\FormCollectionInterface;
+use PHPUnit\Framework\TestCase;
 
-class FormHelperChoiceCheckboxTest extends \PHPUnit_Framework_TestCase
+class FormHelperChoiceCheckboxTest extends TestCase
 {
     public function testInit()
     {
@@ -72,7 +73,7 @@ class FormHelperChoiceCheckboxTest extends \PHPUnit_Framework_TestCase
             ->method('count')
             ->willReturn(1);
 
-        $form = $this->getMockBuilder(FormCollectionInterface::class)->getMock();
+        $form = $this->createMock(FormCollectionInterface::class);
         $form
             ->expects($this->any())
             ->method('getName')

--- a/tests/Helper/FormHelperChoiceRadioTest.php
+++ b/tests/Helper/FormHelperChoiceRadioTest.php
@@ -16,13 +16,14 @@ use Naucon\Form\Mapper\EntityContainerInterface;
 use Naucon\Form\Mapper\Property;
 use Naucon\Form\Tests\Entities\User;
 use Naucon\Utility\Map;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class FormHelperChoiceRadioTest
  *
  * @package Naucon\Form\Tests
  */
-class FormHelperChoiceRadioTest extends \PHPUnit_Framework_TestCase
+class FormHelperChoiceRadioTest extends TestCase
 {
     /**
      * @var FormInterface|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Helper/FormHelperChoiceSelectTest.php
+++ b/tests/Helper/FormHelperChoiceSelectTest.php
@@ -16,8 +16,9 @@ use Naucon\Utility\Map;
 use Naucon\Form\FormInterface;
 use Naucon\Form\Mapper\EntityContainerInterface;
 use Naucon\Form\FormCollectionInterface;
+use PHPUnit\Framework\TestCase;
 
-class FormHelperChoiceSelectTest extends \PHPUnit_Framework_TestCase
+class FormHelperChoiceSelectTest extends TestCase
 {
     public function testInit()
     {
@@ -84,7 +85,7 @@ class FormHelperChoiceSelectTest extends \PHPUnit_Framework_TestCase
             ->method('count')
             ->willReturn(1);
 
-        $form = $this->getMockBuilder(FormCollectionInterface::class)->getMock();
+        $form = $this->createMock(FormCollectionInterface::class);
         $form
             ->expects($this->any())
             ->method('getName')

--- a/tests/Helper/FormHelperFieldHiddenTest.php
+++ b/tests/Helper/FormHelperFieldHiddenTest.php
@@ -16,8 +16,9 @@ use Naucon\Utility\Map;
 use Naucon\Form\FormInterface;
 use Naucon\Form\Mapper\EntityContainerInterface;
 use Naucon\Form\FormCollectionInterface;
+use PHPUnit\Framework\TestCase;
 
-class FormHelperFieldHiddenTest extends \PHPUnit_Framework_TestCase
+class FormHelperFieldHiddenTest extends TestCase
 {
     public function testInit()
     {
@@ -71,7 +72,7 @@ class FormHelperFieldHiddenTest extends \PHPUnit_Framework_TestCase
             ->method('count')
             ->willReturn(1);
 
-        $form = $this->getMockBuilder(FormCollectionInterface::class)->getMock();
+        $form = $this->createMock(FormCollectionInterface::class);
         $form
             ->expects($this->any())
             ->method('getName')

--- a/tests/Helper/FormHelperFieldIdTest.php
+++ b/tests/Helper/FormHelperFieldIdTest.php
@@ -15,13 +15,14 @@ use Naucon\Form\Mapper\EntityContainerInterface;
 use Naucon\Form\Mapper\Property;
 use Naucon\Form\Tests\Entities\User;
 use Naucon\Utility\Map;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class FormHelperFieldIdTest
  *
  * @package Naucon\Form\Tests
  */
-class FormHelperFieldIdTest extends \PHPUnit_Framework_TestCase
+class FormHelperFieldIdTest extends TestCase
 {
     /**
      * @var FormInterface|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Helper/FormHelperFieldNameTest.php
+++ b/tests/Helper/FormHelperFieldNameTest.php
@@ -15,13 +15,14 @@ use Naucon\Form\Mapper\EntityContainerInterface;
 use Naucon\Form\Mapper\Property;
 use Naucon\Form\Tests\Entities\User;
 use Naucon\Utility\Map;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class FormHelperFieldNameTest
  *
  * @package Naucon\Form\Tests
  */
-class FormHelperFieldNameTest extends \PHPUnit_Framework_TestCase
+class FormHelperFieldNameTest extends TestCase
 {
     /**
      * @var FormInterface|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Helper/FormHelperFieldTextTest.php
+++ b/tests/Helper/FormHelperFieldTextTest.php
@@ -16,13 +16,14 @@ use Naucon\Form\Mapper\EntityContainerInterface;
 use Naucon\Form\Mapper\Property;
 use Naucon\Form\Tests\Entities\User;
 use Naucon\Utility\Map;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class FormHelperFieldTextTest
  *
  * @package Naucon\Form\Tests
  */
-class FormHelperFieldTextTest extends \PHPUnit_Framework_TestCase
+class FormHelperFieldTextTest extends TestCase
 {
     /**
      * @var FormInterface|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Helper/FormHelperFieldTextareaTest.php
+++ b/tests/Helper/FormHelperFieldTextareaTest.php
@@ -16,13 +16,14 @@ use Naucon\Form\Mapper\EntityContainerInterface;
 use Naucon\Form\Mapper\Property;
 use Naucon\Form\Tests\Entities\User;
 use Naucon\Utility\Map;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class FormHelperFieldTextareaTest
  *
  * @package Naucon\Form\Tests
  */
-class FormHelperFieldTextareaTest extends \PHPUnit_Framework_TestCase
+class FormHelperFieldTextareaTest extends TestCase
 {
     /**
      * @var FormInterface|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Helper/FormHelperFieldValueTest.php
+++ b/tests/Helper/FormHelperFieldValueTest.php
@@ -15,8 +15,9 @@ use Naucon\Form\Tests\Entities\User;
 use Naucon\Utility\Map;
 use Naucon\Form\FormInterface;
 use Naucon\Form\Mapper\EntityContainerInterface;
+use PHPUnit\Framework\TestCase;
 
-class FormHelperFieldValueTest extends \PHPUnit_Framework_TestCase
+class FormHelperFieldValueTest extends TestCase
 {
     public function testInit()
     {

--- a/tests/Helper/FormHelperMapTest.php
+++ b/tests/Helper/FormHelperMapTest.php
@@ -16,8 +16,9 @@ use Naucon\Form\Helper\FormHelperMap;
 use Naucon\Form\Tests\Entities\User;
 use Naucon\Form\Tests\Helper\FormHelperFieldFoo;
 use Naucon\Form\Tests\Helper\FormHelperFieldBar;
+use PHPUnit\Framework\TestCase;
 
-class FormHelperMapTest extends \PHPUnit_Framework_TestCase
+class FormHelperMapTest extends TestCase
 {
     /**
      * @return    EntityContainerInterface
@@ -35,6 +36,8 @@ class FormHelperMapTest extends \PHPUnit_Framework_TestCase
         $configuration = new Configuration();
         $form = new Form($userEntity, 'testform', $configuration);
         $entityContainer = $form->getFirstEntityContainer();
+
+        $this->assertNotNull($entityContainer);
 
         return $entityContainer;
     }

--- a/tests/Helper/FormHelperOptionRadioTest.php
+++ b/tests/Helper/FormHelperOptionRadioTest.php
@@ -11,13 +11,14 @@ namespace Naucon\Form\Tests;
 
 use Naucon\Form\FormCollectionInterface;
 use Naucon\Form\Helper\FormHelperOptionRadio;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class FormHelperOptionRadioTest
  *
  * @package Naucon\Form\Tests
  */
-class FormHelperOptionRadioTest extends \PHPUnit_Framework_TestCase
+class FormHelperOptionRadioTest extends TestCase
 {
     /**
      * @var FormCollectionInterface|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Mapper/PropertyMapperTest.php
+++ b/tests/Mapper/PropertyMapperTest.php
@@ -15,8 +15,9 @@ use Naucon\Form\Tests\Entities\Product;
 use Naucon\Form\Tests\Entities\Address;
 use Naucon\Form\Tests\Entities\CreditCard;
 use Naucon\Form\Tests\Entities\DirectDebit;
+use PHPUnit\Framework\TestCase;
 
-class PropertyMapperTest extends \PHPUnit_Framework_TestCase
+class PropertyMapperTest extends TestCase
 {
     public function entityProvider()
     {

--- a/tests/Utility/UtilityTest.php
+++ b/tests/Utility/UtilityTest.php
@@ -10,8 +10,9 @@
 namespace Naucon\Form\Tests\Utility;
 
 use Naucon\Form\Utility\Utility;
+use PHPUnit\Framework\TestCase;
 
-class UtilityTest extends \PHPUnit_Framework_TestCase
+class UtilityTest extends TestCase
 {
     public function nameProvider()
     {

--- a/tests/Validator/Constraints/IsEmailValidatorTest.php
+++ b/tests/Validator/Constraints/IsEmailValidatorTest.php
@@ -12,12 +12,11 @@ namespace Naucon\Form\Tests\Validator\Constraints;
 
 use Naucon\Form\Validator\Constraints\IsDecimal;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
-use Symfony\Component\Validator\Tests\Constraints\AbstractConstraintValidatorTest;
-
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 use Naucon\Form\Validator\Constraints\IsEmail;
 use Naucon\Form\Validator\Constraints\IsEmailValidator;
 
-class IsEmailValidatorTest extends AbstractConstraintValidatorTest
+class IsEmailValidatorTest extends ConstraintValidatorTestCase
 {
     protected function createValidator()
     {
@@ -70,7 +69,7 @@ class IsEmailValidatorTest extends AbstractConstraintValidatorTest
      */
     public function testValidateWithWrongConstraint()
     {
-        $this->setExpectedException(UnexpectedTypeException::class);
+        $this->expectException(UnexpectedTypeException::class);
 
         $constraint = new IsDecimal();
 


### PR DESCRIPTION
This raises version requirements for PHP to 7.1 and for Symfony to 3.3.

Includes addition of two missing Symfony dependencies and CI using GitHub Actions.