### PR TITLE
extend-validation-regexp

### DIFF
--- a/src/Validator/Constraints/IsEmailValidator.php
+++ b/src/Validator/Constraints/IsEmailValidator.php
@@ -22,10 +22,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 class IsEmailValidator extends ConstraintValidator
 {
-    /**
-     * @var string
-     */
-    const REGEXP = '/^([a-zA-Z0-9_\-\+]+(?:\.[a-zA-Z0-9_\-\+]+)*\@([a-zA-Z0-9\-\+]+\.?)+[a-zA-Z0-9]{0,10},?)+$/D';
+    const REGEXP = '/^(?![.-])([a-zA-Z0-9_\-\+]+(?:\.[a-zA-Z0-9_\-\+]+)*\@([a-zA-Z0-9\-\+]+\.?)+[a-zA-Z0-9]{0,10},?)+$/D';
 
     /**
      * {@inheritdoc}

--- a/tests/Validator/Constraints/IsEmailValidatorTest.php
+++ b/tests/Validator/Constraints/IsEmailValidatorTest.php
@@ -54,6 +54,7 @@ class IsEmailValidatorTest extends ConstraintValidatorTestCase
             ['yourname@yourdomain.com <Your Name>', false],
             ['your_name.@yourdomain.com', false],
             ['.your_name@yourdomain.com', false],
+            ['-your_name@yourdomain.com', false],
             [0, false],
             [1, false],
             [2.95, false],


### PR DESCRIPTION
Exclude - (dash) as first character in E-Mail Validation to avoid SMTP Server configuration limitations